### PR TITLE
Add support for custom IDB implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "abstract-blob-store": "~3.2.0",
+    "fake-indexeddb": "^2.0.3",
     "tape": "^4.2.2"
   },
   "scripts": {

--- a/readme.markdown
+++ b/readme.markdown
@@ -26,9 +26,11 @@ function readback () {
 var store = require('idb-blob-store')
 ```
 
-## var blob = store()
+## var blob = store(opts)
 
 Create a new blob store.
+
+`opts.indexedDB` and `opts.IDBKeyRange` both default to respective browser implementations.
 
 ## blob.createWriteStream(opts, cb)
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -30,6 +30,7 @@ var store = require('idb-blob-store')
 
 Create a new blob store.
 
+`opts.name` defaults to `idb-blob-store`.
 `opts.indexedDB` and `opts.IDBKeyRange` both default to respective browser implementations.
 
 ## blob.createWriteStream(opts, cb)

--- a/test/abstract.js
+++ b/test/abstract.js
@@ -1,9 +1,17 @@
 var test = require('tape');
 var blob = require('../');
+var fakeIndexedDB = require('fake-indexeddb');
+var fakeIDBKeyRange = require("fake-indexeddb/lib/FDBKeyRange");
+
+var isNode = typeof window === 'undefined';
+var opts = {
+    indexedDB: isNode && fakeIndexedDB,
+    IDBKeyRange: isNode && fakeIDBKeyRange
+};
 
 require('abstract-blob-store/tests')(test, {
     setup: function (t, cb) {
-        cb(null, blob());
+        cb(null, blob(opts));
     },
     teardown: function (t, store, blob, cb) {
         if (blob) store.remove(blob);


### PR DESCRIPTION
This PR adds `indexedDB` and `IDBKeyRange` options to the idb-blob-store constructor.

It also fixes support in environments without a global `window` environment (i.e. node tests & isomorphic clients).

Closes #1 